### PR TITLE
Make name lowercase and add displayName

### DIFF
--- a/syntaxes/tql.tmLanguage.json
+++ b/syntaxes/tql.tmLanguage.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "TQL",
+  "name": "tql",
+  "displayName": "TQL",
   "patterns": [
     {
       "include": "#root"


### PR DESCRIPTION
Syntax highlighters that match markdown code blocks don't work unless its an exact case-sensitive match.