### PR TITLE
Fix highlighting of timestamps

### DIFF
--- a/syntaxes/tql.tmLanguage.json
+++ b/syntaxes/tql.tmLanguage.json
@@ -147,9 +147,8 @@
           ]
         },
         {
-          "name": "constant.numeric",
-          "match": "[0-9][0-9_]*(\\.[0-9][0-9_]*)?([a-zA-Z_][a-zA-Z_0-9]*)?",
-          "comment": "sign is not included because foo-42"
+          "name": "constant.tql.time",
+          "match": "[0-9]{4}-[0-9]{1,2}-[T0-9\\-+:Z]*"
         },
         {
           "name": "constant.tql.ipv4",
@@ -158,6 +157,11 @@
         {
           "name": "constant.tql.ipv6",
           "match": "([0-9a-fA-F]*:){2,}[0-9a-fA-F]*(\\.[0-9]+|:[0-9a-fA-F]*)*"
+        },
+        {
+          "name": "constant.numeric",
+          "match": "[0-9][0-9_]*(\\.[0-9][0-9_]*)?([a-zA-Z_][a-zA-Z_0-9]*)?",
+          "comment": "sign is not included because foo-42"
         },
         {
           "match": "(\\w+)(\\$|::)",


### PR DESCRIPTION
Seems like I forgot to push this local change. This makes it so that `2024-10-16` gets highlighted in a single color instead of highlighting the `-` differently.