### PR TITLE
Add raw strings, fix nested pipelines and drop `pipeline` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"description": "Syntax highlighting for the Tenzir Query Language (TQL)",
 	"icon": "logo.png",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/tenzir/vscode-tql"

--- a/syntaxes/tql.tmLanguage.json
+++ b/syntaxes/tql.tmLanguage.json
@@ -72,7 +72,7 @@
       "patterns": [
         {
           "name": "keyword",
-          "match": "(?<=\\b)(_|is|as|use|return|def|function|pipeline|let|and|or|in|not|let|this|meta|super|for|if|while|match|else)(?=\\b)",
+          "match": "(?<=\\b)(_|is|as|use|return|def|function|let|and|or|in|not|let|this|meta|super|for|if|while|match|else)(?=\\b)",
           "comment": "type|"
         }
       ]
@@ -118,7 +118,7 @@
           "patterns": [
             {
               "name": "tql.record_detected",
-              "begin": "(?=\\w+:)",
+              "begin": "(?=\\w+:(?!:))",
               "patterns": [
                 {
                   "include": "#keywords"
@@ -176,6 +176,11 @@
           }
         },
         {
+          "name": "string.quoted.double.tql",
+          "begin": "r#\"",
+          "end": "\"#"
+        },
+        {
           "name": "entity.name",
           "match": "\\w+(?='|\\$|#)",
           "comment": "\\w+(?=:|'|\\$|#)"
@@ -205,6 +210,11 @@
               "match": "\\\\."
             }
           ]
+        },
+        {
+          "name": "string.quoted.double.tql",
+          "begin": "r\"",
+          "end": "\""
         },
         {
           "name": "keyword.operator",


### PR DESCRIPTION
This PR adds support for `r"…"` and `r#"…"#` strings. 

It also includes a bug-fix for nested pipelines that start with an operator inside a module, such as `every 1s { pipeline::list }`, and reflects our decision to not reserve `pipeline` as a keyword.

Fixes tenzir/issues#2325.