### PR TITLE
Change module style name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Future updates may introduce customization options.
 
 ## Contributing
 
-Contributions are welcome! 🎉  
+Contributions are welcome! 🎉
 If you'd like to improve this extension, please:
 
 - Open an issue on [GitHub](https://github.com/tenzir/vscode-tql/issues)
@@ -55,7 +55,8 @@ vsce publish
 You must have run `vsce login tenzir` once in the past, which requires a valid
 [Azure DevOps Personal Access Token
 (PAT)](https://dev.azure.com/tenzir/_usersSettings/tokens). This token only
-requires the *Marketplace Manage* scope.
+requires the *Marketplace Manage* scope. New users must also be [added as
+contributors](https://marketplace.visualstudio.com/manage/publishers/).
 
 Example output:
 
@@ -106,5 +107,5 @@ of the [VisualStudio Marketplace page][vscode-marketplace].
 
 ## License
 
-This extension is licensed under the **MIT License**.  
+This extension is licensed under the **MIT License**.
 See [LICENSE](./LICENSE.txt) for details.

--- a/syntaxes/tql.tmLanguage.json
+++ b/syntaxes/tql.tmLanguage.json
@@ -180,11 +180,11 @@
         {
           "match": "(\\w+)(\\$|::)",
           "captures": {
-            "0": {
-              "name": "keyword"
-            },
             "1": {
-              "name": "entity.name"
+              "name": "variable"
+            },
+            "2": {
+              "name": "keyword"
             }
           }
         },


### PR DESCRIPTION
This is because the theme used in our docs seems to have very slight differences. Before this change, modules had the same color as operators and functions. Now, they have a different color (orange).

Could have also changed the docs theme instead, but I'm not sure who has the "right" color. Thus I opted to choose a class where both themes use the same color. Note that this class might be rendered differently in non-GitHub themes than before. But for our purposes this does the job.