### PR TITLE
Require PR metadata for changelog entries

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,5 +25,11 @@ jobs:
       - name: Validate Lefthook config
         run: npm run lefthook:validate
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Run Lefthook
         run: npm run lint
+
+      - name: Validate changelog
+        run: uvx tenzir-ship --root changelog validate

--- a/changelog/config.yaml
+++ b/changelog/config.yaml
@@ -2,6 +2,7 @@ id: vscode-tql
 name: VS Code TQL
 description: VS Code extension for TQL syntax highlighting
 repository: tenzir/vscode-tql
+require_pr: true
 release:
   version_files:
     - ../package.json

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,10 @@ pre-push:
     - name: package
       run: npm run package
 
+    - name: changelog
+      glob: "changelog/**"
+      run: uvx tenzir-ship --root changelog validate --lenient
+
 fix:
   parallel: false
   jobs:


### PR DESCRIPTION
## 🔍 Problem

- Changelog entries can still land without PR metadata in this repository.
- Local pre-push validation needs to tolerate missing PR numbers before the first push creates a pull request.

## 🛠️ Solution

- Enable `require_pr: true` for the changelog project.
- Keep CI changelog validation strict.
- Run Lefthook changelog validation with `--lenient` for local pre-push checks.

## 💬 Review

- Release-process-only change; no product changelog entry.

<sub>
📎 Related: tenzir/ship#34
</sub>
